### PR TITLE
WIP: Remove documented electron-prebuilt dep

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ This uses [Electron](https://github.com/atom/electron) to run tests in
 # usage
 
 * Install to your project: `npm install testron --save-dev`
-* Install Electron: `npm install electron-prebuilt --save-dev`
 * Add a `test` script to your `package.json`:
 ```json
 {

--- a/package.json
+++ b/package.json
@@ -28,13 +28,12 @@
   },
   "homepage": "https://github.com/shama/testron#readme",
   "dependencies": {
-    "electron-spawn": "^3.0.0",
+    "electron-spawn": "bendrucker/electron-spawn#prebuilt-latest",
     "minimist": "^1.1.2",
     "tempfile": "^1.1.1",
     "through2": "^2.0.0"
   },
   "devDependencies": {
-    "electron-prebuilt": "^0.30.0",
     "tape": "^4.0.1"
   }
 }


### PR DESCRIPTION
Not ready for merge yet, this is using a git dep until electron-spawn can be patched:

* electron-spawn now depends on electron-prebuilt directly
* see also: https://github.com/maxogden/electron-spawn/pull/18