### PR TITLE
update install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This uses [Electron](https://github.com/atom/electron) to run tests in
 # usage
 
 * Install to your project: `npm install testron --save-dev`
-* Install Electron: `npm install electron-prebuilt --save-dev`
+* Install Electron: `npm install electron-prebuilt@"^0.37.8" --save-dev`
 * Add a `test` script to your `package.json`:
 ```json
 {


### PR DESCRIPTION
Install electron-prebuilt version 0 because version 1 breaks it.