### PR TITLE
Add callback to fs.unlink to fix ERR_INVALID_CALLBACK error when running tests.

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,9 @@ if (process.versions['electron']) {
       electron.stdout.pipe(s.stdout)
       electron.stderr.pipe(s.stderr)
       electron.on('exit', function () {
-        fs.unlink(tmpname)
+        fs.unlink(tmpname, function (err) {
+          if (err) console.error(err)
+        })
       })
     })
     return s


### PR DESCRIPTION
When running the tests in https://github.com/shama/on-load the following error occurs at the end of every test run:

    fs.js:141
        throw new ERR_INVALID_CALLBACK();
        ^

    TypeError [ERR_INVALID_CALLBACK]: Callback must be a function
        at makeCallback (fs.js:141:11)
        at Object.unlink (fs.js:912:14)
        at ChildProcess.<anonymous> (/Users/harry/Downloads/on-load/node_modules/testron/index.js:44:12)
        at ChildProcess.emit (events.js:182:13)
        at Process.ChildProcess._handle.onexit (internal/child_process.js:237:12)

It seems that the `fs.unlink` callback is now mandatory (perhaps due to changes in Node 10's fs module?), so I have added a simple callback which just logs an error to stderr.

Unfortunately the automated tests in this repo are broken. I tested this by manually making the changes and running the https://github.com/shama/on-load tests. This seems like a fairly low-risk change, so I hope that's enough.